### PR TITLE
Update ISO27001 annex control to match latest revision

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -40,7 +40,7 @@ As an example, the change management stipulation shows up in the following subse
 
 SOC2 CC8 - Common Criteria 8
 
-ISO27001 Annex A.14.2.1 - Secure Development Policy
+ISO27001 Annex A.8.25 - Secure development life cycle
 
 In IEC62304 5.1 - 5.8 - Software Development Process
 

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ As an example, the change management stipulation shows up in the following subse
 
 SOC2 CC8 - Common Criteria 8
 
-ISO27001 Annex A.14.2.1 - Secure Development Policy
+ISO27001 Annex A.8.25 - Secure development life cycle
 
 In IEC62304 5.1 - 5.8 - Software Development Process
 


### PR DESCRIPTION
The 2022 revision of the ISO27001 standard changed the numbering of the Annex A controls - Secure development life cycle is now A.8.25

The 2022 revision has been out long enough that there should now be no organisations implementing the 2013 revision; so it's reasonable to assume that people know the new Annex A Controls numbering.

Note that this commit uses the same capitalisation as the standard itself, with the words "development", "life" and "cycle" in lower case. This doesn't match IEC62304 control on the next line of the readme, so stylistically it might be jarring to some readers.